### PR TITLE
Update Goyave link

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -34,7 +34,7 @@ https://github.com/gramework/gramework
 https://github.com/johng-cn/gf
 https://github.com/tusharsoni/copper
 https://github.com/micro/micro
-https://github.com/System-Glitch/goyave
+https://github.com/go-goyave/goyave
 https://github.com/abahmed/gearbox
 https://github.com/yoyofx/yoyogo
 https://github.com/go-kratos/kratos


### PR DESCRIPTION
The goyave framework moved to the go-goyave organization. This PR updates the link to the repository.