### PR TITLE
Fix: `gorilla/mux` is no longer maintained

### DIFF
--- a/list2md.go
+++ b/list2md.go
@@ -53,7 +53,7 @@ Please update **list.txt** (via Pull Request)
 )
 
 var (
-	deprecatedRepos = [2]string{"https://github.com/go-martini/martini", "https://github.com/pilu/traffic"}
+	deprecatedRepos = [3]string{"https://github.com/go-martini/martini", "https://github.com/pilu/traffic", "https://github.com/gorilla/mux"}
 	repos           []Repo
 )
 


### PR DESCRIPTION
The `gorilla/mux` project is now unmaintained:
https://github.com/gorilla#gorilla-toolkit

This PR should cause this entry in the `list.txt` to get the `warning`:
https://github.com/mingrammer/go-web-framework-stars/blob/master/list.txt#L12