### PR TITLE
Update `gorilla/mux` - now maintained again

### DIFF
--- a/list2md.go
+++ b/list2md.go
@@ -53,7 +53,7 @@ Please update **list.txt** (via Pull Request)
 )
 
 var (
-	deprecatedRepos = [3]string{"https://github.com/go-martini/martini", "https://github.com/pilu/traffic", "https://github.com/gorilla/mux"}
+	deprecatedRepos = [3]string{"https://github.com/go-martini/martini", "https://github.com/pilu/traffic"}
 	repos           []Repo
 )
 


### PR DESCRIPTION
Reverts: https://github.com/mingrammer/go-web-framework-stars/pull/74

Due to:  https://github.com/gorilla/.github/pull/8